### PR TITLE
Fix gasPrice, ensure  expected balances are calculated with account f…

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -19,7 +19,9 @@ const config: HardhatUserConfig = {
   },
   defaultNetwork: 'hardhat',
   networks: {
-    hardhat: {},
+    hardhat: {
+      gasPrice: 1000
+    },
     // fantom: {
     //   chainId: 250,
     //   url: 'https://rpcapi.fantom.network',

--- a/test/Router02.js
+++ b/test/Router02.js
@@ -63,6 +63,7 @@ let LP_AMOUNT;
 let ETH_IS_A;
 const INITIAL_EXCHANGE_RATE = oneMantissa;
 const MINIMUM_LIQUIDITY = new BN(1000);
+const GAS_PRICE = 1000;
 
 async function checkETHBalance(
   operation,
@@ -78,13 +79,17 @@ async function checkETHBalance(
     const balanceDiff = bnMantissa(
       (balancePrior * 1 - balanceAfter * 1) / 1e18
     );
-    const expected = bnMantissa((expectedChange * 1 + gasUsed * 1) / 1e18);
+    const expected = bnMantissa(
+      (expectedChange * 1 + gasUsed * GAS_PRICE) / 1e18
+    );
     expectAlmostEqualMantissa(balanceDiff, expected);
   } else {
     const balanceDiff = bnMantissa(
       (balanceAfter * 1 - balancePrior * 1) / 1e18
     );
-    const expected = bnMantissa((expectedChange * 1 - gasUsed * 1) / 1e18);
+    const expected = bnMantissa(
+      (expectedChange * 1 - gasUsed * GAS_PRICE) / 1e18
+    );
     expectAlmostEqualMantissa(balanceDiff, expected);
   }
 }

--- a/test/Router02Vault.js
+++ b/test/Router02Vault.js
@@ -71,6 +71,7 @@ let LP_AMOUNT;
 let ETH_IS_A;
 const INITIAL_EXCHANGE_RATE = oneMantissa;
 const MINIMUM_LIQUIDITY = new BN(1000);
+const GAS_PRICE = 1000;
 
 async function checkETHBalance(
   operation,
@@ -86,13 +87,13 @@ async function checkETHBalance(
     const balanceDiff = bnMantissa(
       (balancePrior * 1 - balanceAfter * 1) / 1e18
     );
-    const expected = bnMantissa((expectedChange * 1 + gasUsed * 1) / 1e18);
+    const expected = bnMantissa((expectedChange * 1 + gasUsed * GAS_PRICE) / 1e18);
     expectAlmostEqualMantissa(balanceDiff, expected);
   } else {
     const balanceDiff = bnMantissa(
       (balanceAfter * 1 - balancePrior * 1) / 1e18
     );
-    const expected = bnMantissa((expectedChange * 1 - gasUsed * 1) / 1e18);
+    const expected = bnMantissa((expectedChange * 1 - gasUsed * GAS_PRICE) / 1e18);
     expectAlmostEqualMantissa(balanceDiff, expected);
   }
 }


### PR DESCRIPTION
…or gasPrice

Issue: The expected price functions weren't accounting for gasPrice when subtracting gasUsed from expected balance. I've set a fixed value, added const in the tests, and reduced test failures from 19 -> 8. 

`npx hardhat test`